### PR TITLE
Refactor services for async compatibility

### DIFF
--- a/backend/services/calendar_service.py
+++ b/backend/services/calendar_service.py
@@ -4,6 +4,7 @@ Handles calendar events, scheduling, and availability management
 """
 
 import logging
+import asyncio
 from typing import Dict, Any, Optional, List
 from datetime import datetime, timedelta
 import json
@@ -66,10 +67,12 @@ class GoogleCalendarService:
             
             # Refresh credentials if needed
             if self.credentials and self.credentials.expired and self.credentials.refresh_token:
-                self.credentials.refresh(Request())
-            
+                await asyncio.to_thread(self.credentials.refresh, Request())
+
             if self.credentials and self.credentials.valid:
-                self.service = build('calendar', 'v3', credentials=self.credentials)
+                self.service = await asyncio.to_thread(
+                    build, 'calendar', 'v3', credentials=self.credentials
+                )
                 return {
                     'success': True,
                     'message': 'Google Calendar service initialized successfully',
@@ -178,13 +181,16 @@ class GoogleCalendarService:
                 }
             }
             
-            # Create the event
-            created_event = self.service.events().insert(
-                calendarId=calendar_id,
-                body=event,
-                conferenceDataVersion=1,
-                sendUpdates='all'
-            ).execute()
+            # Create the event in a thread to avoid blocking
+            def _insert():
+                return self.service.events().insert(
+                    calendarId=calendar_id,
+                    body=event,
+                    conferenceDataVersion=1,
+                    sendUpdates='all'
+                ).execute()
+
+            created_event = await asyncio.to_thread(_insert)
             
             return {
                 'success': True,
@@ -243,15 +249,18 @@ class GoogleCalendarService:
             if not end_date:
                 end_date = start_date + timedelta(days=30)
             
-            # Get events
-            events_result = self.service.events().list(
-                calendarId=calendar_id,
-                timeMin=start_date.isoformat() + 'Z',
-                timeMax=end_date.isoformat() + 'Z',
-                maxResults=max_results,
-                singleEvents=True,
-                orderBy='startTime'
-            ).execute()
+            # Get events in a thread to avoid blocking
+            def _list():
+                return self.service.events().list(
+                    calendarId=calendar_id,
+                    timeMin=start_date.isoformat() + 'Z',
+                    timeMax=end_date.isoformat() + 'Z',
+                    maxResults=max_results,
+                    singleEvents=True,
+                    orderBy='startTime'
+                ).execute()
+
+            events_result = await asyncio.to_thread(_list)
             
             events = events_result.get('items', [])
             
@@ -394,11 +403,14 @@ class GoogleCalendarService:
                     'error': 'Google Calendar service not initialized'
                 }
             
-            # Get existing event
-            event = self.service.events().get(
-                calendarId=calendar_id,
-                eventId=event_id
-            ).execute()
+            # Get existing event in a thread
+            def _get():
+                return self.service.events().get(
+                    calendarId=calendar_id,
+                    eventId=event_id
+                ).execute()
+
+            event = await asyncio.to_thread(_get)
             
             # Update fields if provided
             if title:
@@ -416,13 +428,16 @@ class GoogleCalendarService:
                     'timeZone': 'America/Sao_Paulo',
                 }
             
-            # Update the event
-            updated_event = self.service.events().update(
-                calendarId=calendar_id,
-                eventId=event_id,
-                body=event,
-                sendUpdates='all'
-            ).execute()
+            # Update the event in a thread
+            def _update():
+                return self.service.events().update(
+                    calendarId=calendar_id,
+                    eventId=event_id,
+                    body=event,
+                    sendUpdates='all'
+                ).execute()
+
+            updated_event = await asyncio.to_thread(_update)
             
             return {
                 'success': True,
@@ -466,12 +481,15 @@ class GoogleCalendarService:
                     'error': 'Google Calendar service not initialized'
                 }
             
-            # Delete the event
-            self.service.events().delete(
-                calendarId=calendar_id,
-                eventId=event_id,
-                sendUpdates='all'
-            ).execute()
+            # Delete the event in a thread
+            def _delete():
+                self.service.events().delete(
+                    calendarId=calendar_id,
+                    eventId=event_id,
+                    sendUpdates='all'
+                ).execute()
+
+            await asyncio.to_thread(_delete)
             
             return {
                 'success': True,

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -4,7 +4,8 @@ Handles email sending, templates, and delivery tracking
 """
 
 import smtplib
-import requests
+import asyncio
+import aiohttp
 import logging
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -89,30 +90,29 @@ class SendGridEmailService:
                     "value": content
                 }]
             
-            # Send email
-            response = requests.post(
-                f"{self.base_url}/mail/send",
-                headers=self.headers,
-                json=email_data
-            )
-            
-            if response.status_code == 202:
-                return {
-                    'success': True,
-                    'message': 'Email sent successfully',
-                    'recipients': to_emails,
-                    'subject': subject,
-                    'sent_at': datetime.utcnow().isoformat(),
-                    'provider': 'sendgrid'
-                }
-            else:
-                error_data = response.json() if response.headers.get('content-type') == 'application/json' else {}
-                return {
-                    'success': False,
-                    'error': error_data.get('errors', [{'message': f'HTTP {response.status_code}'}])[0].get('message'),
-                    'status_code': response.status_code,
-                    'provider': 'sendgrid'
-                }
+            # Send email using aiohttp
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.post(
+                    f"{self.base_url}/mail/send",
+                    json=email_data
+                ) as response:
+                    if response.status == 202:
+                        return {
+                            'success': True,
+                            'message': 'Email sent successfully',
+                            'recipients': to_emails,
+                            'subject': subject,
+                            'sent_at': datetime.utcnow().isoformat(),
+                            'provider': 'sendgrid'
+                        }
+                    else:
+                        error_data = await response.json() if response.headers.get('content-type') == 'application/json' else {}
+                        return {
+                            'success': False,
+                            'error': error_data.get('errors', [{'message': f'HTTP {response.status}'}])[0].get('message'),
+                            'status_code': response.status,
+                            'provider': 'sendgrid'
+                        }
                 
         except Exception as e:
             logger.error(f"Error sending email via SendGrid: {str(e)}")
@@ -291,12 +291,15 @@ class SMTPEmailService:
             else:
                 msg.attach(MIMEText(content, 'plain', 'utf-8'))
             
-            # Send email
-            with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
-                if self.use_tls:
-                    server.starttls()
-                server.login(self.username, self.password)
-                server.send_message(msg)
+            # Send email in a thread to avoid blocking
+            def _send():
+                with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
+                    if self.use_tls:
+                        server.starttls()
+                    server.login(self.username, self.password)
+                    server.send_message(msg)
+
+            await asyncio.to_thread(_send)
             
             return {
                 'success': True,

--- a/backend/services/evolution_api_service.py
+++ b/backend/services/evolution_api_service.py
@@ -3,7 +3,8 @@ Evolution API Service for WhatsApp Integration
 Handles WhatsApp messaging, instance management, and QR code generation
 """
 
-import requests
+import asyncio
+import aiohttp
 import json
 import logging
 import qrcode
@@ -85,28 +86,27 @@ class EvolutionAPIService:
                     "base64": False
                 }
             
-            response = requests.post(
-                f"{self.base_url}/instance/create",
-                headers=self.headers,
-                json=instance_data
-            )
-            
-            if response.status_code in [200, 201]:
-                result = response.json()
-                return {
-                    'success': True,
-                    'instance_name': instance_name,
-                    'instance_data': result,
-                    'message': 'Instance created successfully',
-                    'created_at': datetime.utcnow().isoformat()
-                }
-            else:
-                error_data = response.json() if response.headers.get('content-type') == 'application/json' else {}
-                return {
-                    'success': False,
-                    'error': error_data.get('message', f'HTTP {response.status_code}'),
-                    'status_code': response.status_code
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.post(
+                    f"{self.base_url}/instance/create",
+                    json=instance_data
+                ) as response:
+                    if response.status in [200, 201]:
+                        result = await response.json()
+                        return {
+                            'success': True,
+                            'instance_name': instance_name,
+                            'instance_data': result,
+                            'message': 'Instance created successfully',
+                            'created_at': datetime.utcnow().isoformat()
+                        }
+                    else:
+                        error_data = await response.json() if response.headers.get('content-type') == 'application/json' else {}
+                        return {
+                            'success': False,
+                            'error': error_data.get('message', f'HTTP {response.status}'),
+                            'status_code': response.status
+                        }
                 
         except Exception as e:
             logger.error(f"Error creating Evolution API instance: {str(e)}")
@@ -126,22 +126,23 @@ class EvolutionAPIService:
             Dict with QR code data
         """
         try:
-            response = requests.get(
-                f"{self.base_url}/instance/connect/{instance_name}",
-                headers=self.headers
-            )
-            
-            if response.status_code == 200:
-                result = response.json()
-                
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.get(
+                    f"{self.base_url}/instance/connect/{instance_name}"
+                ) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                    else:
+                        result = None
+            if result is not None:
                 # Check if QR code is available
                 if result.get('base64'):
                     # Generate QR code image from base64
                     qr_base64 = result['base64']
-                    
+
                     # Also generate a clean QR code image
                     qr_code_image = await self._generate_qr_code_image(result.get('code', ''))
-                    
+
                     return {
                         'success': True,
                         'qr_code_base64': qr_base64,
@@ -160,8 +161,8 @@ class EvolutionAPIService:
             else:
                 return {
                     'success': False,
-                    'error': f'Failed to get QR code: HTTP {response.status_code}',
-                    'status_code': response.status_code
+                    'error': 'Failed to get QR code',
+                    'status_code': 500
                 }
                 
         except Exception as e:
@@ -212,26 +213,25 @@ class EvolutionAPIService:
             Dict with instance status
         """
         try:
-            response = requests.get(
-                f"{self.base_url}/instance/connectionState/{instance_name}",
-                headers=self.headers
-            )
-            
-            if response.status_code == 200:
-                result = response.json()
-                return {
-                    'success': True,
-                    'instance_name': instance_name,
-                    'status': result.get('state', 'unknown'),
-                    'connected': result.get('state') == 'open',
-                    'last_update': datetime.utcnow().isoformat()
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': f'Failed to get instance status: HTTP {response.status_code}',
-                    'status_code': response.status_code
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.get(
+                    f"{self.base_url}/instance/connectionState/{instance_name}"
+                ) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        return {
+                            'success': True,
+                            'instance_name': instance_name,
+                            'status': result.get('state', 'unknown'),
+                            'connected': result.get('state') == 'open',
+                            'last_update': datetime.utcnow().isoformat()
+                        }
+                    else:
+                        return {
+                            'success': False,
+                            'error': f'Failed to get instance status: HTTP {response.status}',
+                            'status_code': response.status
+                        }
                 
         except Exception as e:
             logger.error(f"Error getting instance status: {str(e)}")
@@ -272,29 +272,28 @@ class EvolutionAPIService:
                 }
             }
             
-            response = requests.post(
-                f"{self.base_url}/message/sendText/{instance_name}",
-                headers=self.headers,
-                json=message_data
-            )
-            
-            if response.status_code == 200:
-                result = response.json()
-                return {
-                    'success': True,
-                    'message_id': result.get('key', {}).get('id'),
-                    'recipient': clean_number,
-                    'message': message,
-                    'sent_at': datetime.utcnow().isoformat(),
-                    'instance_name': instance_name
-                }
-            else:
-                error_data = response.json() if response.headers.get('content-type') == 'application/json' else {}
-                return {
-                    'success': False,
-                    'error': error_data.get('message', f'HTTP {response.status_code}'),
-                    'status_code': response.status_code
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.post(
+                    f"{self.base_url}/message/sendText/{instance_name}",
+                    json=message_data
+                ) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        return {
+                            'success': True,
+                            'message_id': result.get('key', {}).get('id'),
+                            'recipient': clean_number,
+                            'message': message,
+                            'sent_at': datetime.utcnow().isoformat(),
+                            'instance_name': instance_name
+                        }
+                    else:
+                        error_data = await response.json() if response.headers.get('content-type') == 'application/json' else {}
+                        return {
+                            'success': False,
+                            'error': error_data.get('message', f'HTTP {response.status}'),
+                            'status_code': response.status
+                        }
                 
         except Exception as e:
             logger.error(f"Error sending message: {str(e)}")
@@ -393,23 +392,22 @@ Clique no link para realizar o pagamento."""
             Dict with deletion result
         """
         try:
-            response = requests.delete(
-                f"{self.base_url}/instance/delete/{instance_name}",
-                headers=self.headers
-            )
-            
-            if response.status_code == 200:
-                return {
-                    'success': True,
-                    'message': f'Instance {instance_name} deleted successfully',
-                    'instance_name': instance_name
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': f'Failed to delete instance: HTTP {response.status_code}',
-                    'status_code': response.status_code
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.delete(
+                    f"{self.base_url}/instance/delete/{instance_name}"
+                ) as response:
+                    if response.status == 200:
+                        return {
+                            'success': True,
+                            'message': f'Instance {instance_name} deleted successfully',
+                            'instance_name': instance_name
+                        }
+                    else:
+                        return {
+                            'success': False,
+                            'error': f'Failed to delete instance: HTTP {response.status}',
+                            'status_code': response.status
+                        }
                 
         except Exception as e:
             logger.error(f"Error deleting instance: {str(e)}")
@@ -426,24 +424,23 @@ Clique no link para realizar o pagamento."""
             Dict with instances list
         """
         try:
-            response = requests.get(
-                f"{self.base_url}/instance/fetchInstances",
-                headers=self.headers
-            )
-            
-            if response.status_code == 200:
-                result = response.json()
-                return {
-                    'success': True,
-                    'instances': result.get('instances', []),
-                    'count': len(result.get('instances', []))
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': f'Failed to list instances: HTTP {response.status_code}',
-                    'status_code': response.status_code
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.get(
+                    f"{self.base_url}/instance/fetchInstances"
+                ) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        return {
+                            'success': True,
+                            'instances': result.get('instances', []),
+                            'count': len(result.get('instances', []))
+                        }
+                    else:
+                        return {
+                            'success': False,
+                            'error': f'Failed to list instances: HTTP {response.status}',
+                            'status_code': response.status
+                        }
                 
         except Exception as e:
             logger.error(f"Error listing instances: {str(e)}")
@@ -478,26 +475,25 @@ Clique no link para realizar o pagamento."""
                 "base64": False
             }
             
-            response = requests.post(
-                f"{self.base_url}/webhook/set/{instance_name}",
-                headers=self.headers,
-                json=webhook_data
-            )
-            
-            if response.status_code == 200:
-                return {
-                    'success': True,
-                    'message': 'Webhook configured successfully',
-                    'instance_name': instance_name,
-                    'webhook_url': webhook_url,
-                    'events': webhook_events
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': f'Failed to set webhook: HTTP {response.status_code}',
-                    'status_code': response.status_code
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.post(
+                    f"{self.base_url}/webhook/set/{instance_name}",
+                    json=webhook_data
+                ) as response:
+                    if response.status == 200:
+                        return {
+                            'success': True,
+                            'message': 'Webhook configured successfully',
+                            'instance_name': instance_name,
+                            'webhook_url': webhook_url,
+                            'events': webhook_events
+                        }
+                    else:
+                        return {
+                            'success': False,
+                            'error': f'Failed to set webhook: HTTP {response.status}',
+                            'status_code': response.status
+                        }
                 
         except Exception as e:
             logger.error(f"Error setting webhook: {str(e)}")

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -4,8 +4,8 @@ Handles payment link generation and processing
 """
 
 import stripe
-import requests
-import json
+import asyncio
+import aiohttp
 import logging
 from typing import Dict, Any, Optional, List
 from datetime import datetime, timedelta
@@ -53,17 +53,17 @@ class StripePaymentService:
             Dict with payment link data
         """
         try:
-            # Create price object
-            price = stripe.Price.create(
+            # Create price object using a thread to avoid blocking
+            price = await asyncio.to_thread(
+                stripe.Price.create,
                 unit_amount=int(amount * 100),  # Convert to cents
                 currency=currency,
-                product_data={
-                    'name': description or 'Pagamento SDK Agent'
-                }
+                product_data={'name': description or 'Pagamento SDK Agent'}
             )
-            
-            # Create payment link
-            payment_link = stripe.PaymentLink.create(
+
+            # Create payment link in a separate thread
+            payment_link = await asyncio.to_thread(
+                stripe.PaymentLink.create,
                 line_items=[{
                     'price': price.id,
                     'quantity': 1,
@@ -122,7 +122,10 @@ class StripePaymentService:
     async def get_payment_status(self, payment_link_id: str) -> Dict[str, Any]:
         """Get payment link status from Stripe"""
         try:
-            payment_link = stripe.PaymentLink.retrieve(payment_link_id)
+            payment_link = await asyncio.to_thread(
+                stripe.PaymentLink.retrieve,
+                payment_link_id
+            )
             return {
                 'success': True,
                 'status': payment_link.active,
@@ -205,21 +208,26 @@ class AsaasPaymentService:
             if customer_data and customer_data.get('success'):
                 payment_data["customer"] = customer_data["customer_id"]
             
-            # Create payment
-            response = requests.post(
-                f"{self.base_url}/payments",
-                headers=self.headers,
-                json=payment_data
-            )
-            
-            if response.status_code == 200:
-                payment = response.json()
-                
+            # Create payment using aiohttp for non-blocking request
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.post(
+                    f"{self.base_url}/payments",
+                    json=payment_data
+                ) as response:
+                    if response.status == 200:
+                        payment = await response.json()
+                        error_msg = None
+                    else:
+                        error_data = await response.json()
+                        error_msg = error_data.get("errors", [{"description": f"HTTP {response.status}"}])[0]["description"]
+                        payment = None
+
+            if payment:
                 # Generate PIX QR Code if PIX payment
                 pix_data = None
                 if billing_type in ["PIX", "UNDEFINED"]:
                     pix_data = await self._generate_pix_qr_code(payment["id"])
-                
+
                 return {
                     'success': True,
                     'payment_id': payment["id"],
@@ -236,7 +244,6 @@ class AsaasPaymentService:
                     'provider': 'asaas'
                 }
             else:
-                error_msg = response.json().get("errors", [{"description": "Unknown error"}])[0]["description"]
                 return {
                     'success': False,
                     'error': error_msg,
@@ -262,19 +269,19 @@ class AsaasPaymentService:
                 search_params["cpfCnpj"] = cpf
             
             if search_params:
-                response = requests.get(
-                    f"{self.base_url}/customers",
-                    headers=self.headers,
-                    params=search_params
-                )
-                
-                if response.status_code == 200:
-                    customers = response.json()["data"]
-                    if customers:
-                        return {
-                            'success': True,
-                            'customer_id': customers[0]["id"]
-                        }
+                async with aiohttp.ClientSession(headers=self.headers) as session:
+                    async with session.get(
+                        f"{self.base_url}/customers",
+                        params=search_params
+                    ) as response:
+                        if response.status == 200:
+                            data = await response.json()
+                            customers = data["data"]
+                            if customers:
+                                return {
+                                    'success': True,
+                                    'customer_id': customers[0]["id"]
+                                }
             
             # Create new customer
             customer_data = {
@@ -283,20 +290,19 @@ class AsaasPaymentService:
                 "cpfCnpj": cpf
             }
             
-            response = requests.post(
-                f"{self.base_url}/customers",
-                headers=self.headers,
-                json=customer_data
-            )
-            
-            if response.status_code == 200:
-                customer = response.json()
-                return {
-                    'success': True,
-                    'customer_id': customer["id"]
-                }
-            else:
-                return {'success': False, 'error': 'Failed to create customer'}
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.post(
+                    f"{self.base_url}/customers",
+                    json=customer_data
+                ) as response:
+                    if response.status == 200:
+                        customer = await response.json()
+                        return {
+                            'success': True,
+                            'customer_id': customer["id"]
+                        }
+                    else:
+                        return {'success': False, 'error': 'Failed to create customer'}
                 
         except Exception as e:
             logger.error(f"Error managing Asaas customer: {str(e)}")
@@ -305,15 +311,14 @@ class AsaasPaymentService:
     async def _generate_pix_qr_code(self, payment_id: str) -> Dict[str, Any]:
         """Generate PIX QR code for payment"""
         try:
-            response = requests.get(
-                f"{self.base_url}/payments/{payment_id}/pixQrCode",
-                headers=self.headers
-            )
-            
-            if response.status_code == 200:
-                return response.json()
-            else:
-                return {}
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.get(
+                    f"{self.base_url}/payments/{payment_id}/pixQrCode"
+                ) as response:
+                    if response.status == 200:
+                        return await response.json()
+                    else:
+                        return {}
                 
         except Exception as e:
             logger.error(f"Error generating PIX QR code: {str(e)}")
@@ -322,26 +327,25 @@ class AsaasPaymentService:
     async def get_payment_status(self, payment_id: str) -> Dict[str, Any]:
         """Get payment status from Asaas"""
         try:
-            response = requests.get(
-                f"{self.base_url}/payments/{payment_id}",
-                headers=self.headers
-            )
-            
-            if response.status_code == 200:
-                payment = response.json()
-                return {
-                    'success': True,
-                    'status': payment.get("status"),
-                    'value': payment.get("value"),
-                    'due_date': payment.get("dueDate"),
-                    'provider': 'asaas'
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': 'Payment not found',
-                    'provider': 'asaas'
-                }
+            async with aiohttp.ClientSession(headers=self.headers) as session:
+                async with session.get(
+                    f"{self.base_url}/payments/{payment_id}"
+                ) as response:
+                    if response.status == 200:
+                        payment = await response.json()
+                        return {
+                            'success': True,
+                            'status': payment.get("status"),
+                            'value': payment.get("value"),
+                            'due_date': payment.get("dueDate"),
+                            'provider': 'asaas'
+                        }
+                    else:
+                        return {
+                            'success': False,
+                            'error': 'Payment not found',
+                            'provider': 'asaas'
+                        }
                 
         except Exception as e:
             logger.error(f"Error getting Asaas payment status: {str(e)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -1,0 +1,11 @@
+import pytest
+from datetime import datetime, timedelta
+from backend.services.calendar_service import GoogleCalendarService
+
+@pytest.mark.asyncio
+async def test_calendar_uninitialized():
+    service = GoogleCalendarService()
+    start = datetime.utcnow()
+    end = start + timedelta(hours=1)
+    result = await service.check_availability(start, end)
+    assert result["success"] is False

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,0 +1,29 @@
+import pytest
+import smtplib
+from backend.services.email_service import SMTPEmailService
+
+class DummySMTP:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def starttls(self):
+        pass
+    def login(self, user, pwd):
+        pass
+    def send_message(self, msg):
+        pass
+
+@pytest.mark.asyncio
+async def test_smtp_send_email(monkeypatch):
+    monkeypatch.setattr(smtplib, "SMTP", DummySMTP)
+    service = SMTPEmailService("smtp.test", 25, "user", "pass")
+    result = await service.send_email(
+        to_emails=["a@example.com"],
+        subject="Hi",
+        content="<p>Hello</p>",
+        from_email="from@example.com"
+    )
+    assert result["success"] is True

--- a/tests/test_evolution_api_service.py
+++ b/tests/test_evolution_api_service.py
@@ -1,0 +1,8 @@
+import pytest
+from backend.services.evolution_api_service import EvolutionAPIService
+
+@pytest.mark.asyncio
+async def test_generate_qr_code_image():
+    service = EvolutionAPIService("http://example.com")
+    data = await service._generate_qr_code_image("hello")
+    assert data.startswith("data:image/png;base64,")

--- a/tests/test_payment_service.py
+++ b/tests/test_payment_service.py
@@ -1,0 +1,17 @@
+import pytest
+from decimal import Decimal
+import stripe
+from backend.services.payment_service import StripePaymentService
+
+class DummyObj:
+    def __init__(self, **entries):
+        self.__dict__.update(entries)
+
+@pytest.mark.asyncio
+async def test_stripe_create_payment_link(monkeypatch):
+    monkeypatch.setattr(stripe.Price, "create", lambda **kw: DummyObj(id="price_123"))
+    monkeypatch.setattr(stripe.PaymentLink, "create", lambda **kw: DummyObj(id="plink_123", url="https://example.com"))
+    service = StripePaymentService("sk_test")
+    result = await service.create_payment_link(amount=Decimal("10.00"))
+    assert result["success"] is True
+    assert result["url"] == "https://example.com"


### PR DESCRIPTION
## Summary
- avoid blocking Stripe API calls by running stripe operations in threads
- switch Asaas, SendGrid, Evolution API calls to aiohttp and offload SMTP work to thread
- wrap Google Calendar API interactions with asyncio.to_thread

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06f6f69e88322bc973d7ff1e732db