### PR TITLE
chore: configure cors origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,8 @@ GROQ_API_KEY=gsk_xxxxx
 
 # Configurações de Segurança
 SECRET_KEY=your-secret-key-change-in-production
-CORS_ORIGINS=*
+# Lista de origens permitidas (separadas por vírgula)
+CORS_ORIGINS=https://seu-dominio.com,https://app.seu-dominio.com
 
 # Configurações de Upload e Cache
 UPLOAD_DIR=./uploads

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ HOST=0.0.0.0
 PORT=8000
 DEBUG=false
 DATABASE_URL=sqlite:///./agents.db
+# Origens permitidas (separadas por vírgula)
+CORS_ORIGINS=https://seu-dominio.com
 ```
 
 ## ⚡ Execução e Acesso

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -142,6 +142,8 @@ HOST=0.0.0.0
 PORT=8000
 DEBUG=false
 DATABASE_URL=sqlite:///./agents.db
+# Origens permitidas (separadas por vírgula)
+CORS_ORIGINS=https://seu-dominio.com
 ```
 
 ## ⚡ Execução e Acesso

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,10 +94,7 @@ app = FastAPI(
 # CORS configuration
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    **config.get_cors_config(),
 )
 
 # Health check endpoint


### PR DESCRIPTION
## Summary
- load CORS settings from `Config.get_cors_config()` instead of allowing all origins
- document `CORS_ORIGINS` environment variable for permitted origins

## Testing
- `python -m pytest`
- `python -m py_compile backend/main.py backend/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b06f719e6c83229f130394eac6b704