### PR TITLE
feat: allow configurable API base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ uploads/
 .DS_Store
 Thumbs.db
 
+# Frontend configuration
+frontend/config.js
+
 # IDE files
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ DEBUG=false
 DATABASE_URL=sqlite:///./agents.db
 ```
 
+### 🌐 Configuração do Frontend
+
+O frontend obtém a URL da API a partir de `window.API_BASE_URL`. Para personalizar:
+
+1. Copie `frontend/config.example.js` para `frontend/config.js` e ajuste o valor desejado.
+2. Alternativamente, defina a variável de ambiente `API_BASE_URL` antes de executar `start_frontend.sh` ou `start_frontend.bat` e o arquivo será gerado automaticamente.
+
+Se nenhuma configuração for fornecida, o frontend usará o caminho relativo `/api`.
+
 ## ⚡ Execução e Acesso
 
 ### 🚀 Inicialização

--- a/frontend/config.example.js
+++ b/frontend/config.example.js
@@ -1,0 +1,1 @@
+window.API_BASE_URL = 'http://localhost:8001/api';

--- a/frontend/debug_test.html
+++ b/frontend/debug_test.html
@@ -86,9 +86,10 @@
         <div id="status-result" class="test-result"></div>
     </div>
 
+    <script src="config.js"></script>
     <script>
         // Configurações
-        const API_BASE_URL = 'http://localhost:8001/api';
+        const API_BASE_URL = window.API_BASE_URL || '/api';
 
         // Função utilitária para fetch com timeout
         async function fetchWithTimeout(url, options = {}) {

--- a/frontend/diagnostic.html
+++ b/frontend/diagnostic.html
@@ -132,8 +132,9 @@
         <div id="agents-result" class="test-result"></div>
     </div>
 
+    <script src="config.js"></script>
     <script>
-        const API_BASE_URL = 'http://localhost:8001/api';
+        const API_BASE_URL = window.API_BASE_URL || '/api';
 
         // Utilitário para exibir resultados
         function displayResult(elementId, message, type = 'info') {

--- a/frontend/form_debug.html
+++ b/frontend/form_debug.html
@@ -117,6 +117,7 @@ Se aparecer algum erro em vermelho, copie e cole aqui para análise.
         </div>
     </div>
 
+    <script src="config.js"></script>
     <script>
         function displayResult(elementId, message, type = 'info') {
             const element = document.getElementById(elementId);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -541,6 +541,7 @@
         </div>
     </div>
 
+    <script src="config.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,5 +1,5 @@
 // API Base URL
-const API_BASE_URL = 'http://localhost:8001/api';
+const API_BASE_URL = window.API_BASE_URL || '/api';
 
 // Configuration constants
 const CONFIG = {

--- a/frontend/test_agent_creation.html
+++ b/frontend/test_agent_creation.html
@@ -223,8 +223,9 @@
         </div>
     </div>
 
+    <script src="config.js"></script>
     <script>
-        const API_BASE_URL = 'http://localhost:8001/api';
+        const API_BASE_URL = window.API_BASE_URL || '/api';
         let currentAgentId = null;
         let currentAgentCode = '';
 

--- a/start_frontend.bat
+++ b/start_frontend.bat
@@ -2,5 +2,16 @@
 echo Iniciando frontend do Gerador de Agentes...
 echo Servidor local na porta 8080
 cd /d "%~dp0"
+
+REM Generate config.js from environment variable or example
+if not "%API_BASE_URL%"=="" (
+    echo window.API_BASE_URL = '%API_BASE_URL%';>frontend\config.js
+) else (
+    if not exist frontend\config.js (
+        copy frontend\config.example.js frontend\config.js >nul 2>&1
+        if errorlevel 1 echo window.API_BASE_URL = '/api';>frontend\config.js
+    )
+)
+
 python -m http.server 8080 --directory frontend
 pause

--- a/start_frontend.sh
+++ b/start_frontend.sh
@@ -2,4 +2,12 @@
 echo "Iniciando frontend do Gerador de Agentes..."
 echo "Servidor local na porta 8080"
 cd "$(dirname "$0")"
+
+# Generate config.js from environment variable or example
+if [ -n "$API_BASE_URL" ]; then
+  echo "window.API_BASE_URL = '$API_BASE_URL';" > frontend/config.js
+elif [ ! -f frontend/config.js ]; then
+  cp frontend/config.example.js frontend/config.js 2>/dev/null || echo "window.API_BASE_URL = '/api';" > frontend/config.js
+fi
+
 python -m http.server 8080 --directory frontend


### PR DESCRIPTION
## Summary
- load API base URL from global `window.API_BASE_URL` with `/api` fallback
- add example config and scripts to generate `config.js` from `API_BASE_URL`
- document frontend configuration and ignore `frontend/config.js`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06f71e5ec8322814010d86a212400