### PR TITLE
Add initial tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi==0.104.1 pydantic==2.9.2 uvicorn==0.24.0 sqlalchemy==2.0.23 python-dotenv==1.0.0 python-multipart==0.0.6 requests httpx==0.27.2 anyio==3.7.1 pytest pytest-asyncio
+      - name: Run tests
+        run: pytest -q

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for SDK agents."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,72 @@
+import os
+import sys
+from unittest.mock import MagicMock
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(PROJECT_ROOT)
+sys.path.append(os.path.join(PROJECT_ROOT, 'backend'))
+
+# Mock external dependencies
+sys.modules['stripe'] = MagicMock()
+sys.modules['qrcode'] = MagicMock()
+pil_mock = MagicMock()
+sys.modules['PIL'] = pil_mock
+sys.modules['PIL.Image'] = MagicMock()
+sys.modules['google'] = MagicMock()
+sys.modules['google.oauth2'] = MagicMock()
+sys.modules['google.oauth2.credentials'] = MagicMock()
+sys.modules['google.auth'] = MagicMock()
+sys.modules['google.auth.transport'] = MagicMock()
+sys.modules['google.auth.transport.requests'] = MagicMock()
+sys.modules['google_auth_oauthlib'] = MagicMock()
+sys.modules['google_auth_oauthlib.flow'] = MagicMock()
+sys.modules['googleapiclient'] = MagicMock()
+sys.modules['googleapiclient.discovery'] = MagicMock()
+sys.modules['googleapiclient.errors'] = MagicMock()
+
+# Configure test database before importing app
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+
+from backend.database import DatabaseManager
+from backend.main import app
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    DatabaseManager.reset_db()
+    yield
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    response = client.get('/api/health')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['status'] == 'healthy'
+
+def test_create_and_get_agent():
+    payload = {
+        'name': 'Test Agent',
+        'specialization': 'sales',
+        'description': 'Agent for testing',
+        'model': 'openai/gpt-3.5-turbo',
+        'instructions': 'Be helpful',
+        'whatsapp_config': {},
+        'scheduling_config': {}
+    }
+    create_resp = client.post('/api/agents', json=payload)
+    assert create_resp.status_code == 200
+    created = create_resp.json()
+    agent_id = created['id']
+
+    list_resp = client.get('/api/agents')
+    assert list_resp.status_code == 200
+    agents = list_resp.json()
+    assert any(a['id'] == agent_id for a in agents)
+
+    get_resp = client.get(f'/api/agents/{agent_id}')
+    assert get_resp.status_code == 200
+    agent = get_resp.json()
+    assert agent['name'] == payload['name']

--- a/tests/test_payment_service.py
+++ b/tests/test_payment_service.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from decimal import Decimal
+from unittest.mock import MagicMock
+import pytest
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(PROJECT_ROOT)
+sys.path.append(os.path.join(PROJECT_ROOT, 'backend'))
+
+# Mock stripe module before importing service
+sys.modules['stripe'] = MagicMock()
+
+from backend.services.payment_service import PaymentManager
+
+
+@pytest.mark.asyncio
+async def test_create_payment_link_without_provider():
+    manager = PaymentManager()
+    result = await manager.create_payment_link('stripe', Decimal('10.00'))
+    assert result['success'] is False
+    assert 'Provider stripe not configured' in result['error']
+
+
+def test_get_available_providers():
+    manager = PaymentManager(stripe_config={'api_key': 'sk_test'})
+    providers = manager.get_available_providers()
+    assert providers == ['stripe']


### PR DESCRIPTION
## Summary
- add backend package initializer
- add unit tests for API endpoints and payment manager
- run tests in GitHub Actions with required dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06f795f44832291d25967457a1319